### PR TITLE
Exclude React.Fragment since it's useless and causing warnings (Fix #5)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,17 @@ export default function reactElementInfo({types: t}) {
 
       const newAttributes = [];
 
-      if (openingElement.name && openingElement.name.name) {
-        newAttributes.push(t.jSXAttribute(
-          t.jSXIdentifier(nodeNameAttr),
-          t.stringLiteral(openingElement.name.name),
-        ));
+      const elementName = (openingElement.name && openingElement.name.name) ||
+        (openingElement.name.property && openingElement.name.property.name);
+
+      if (elementName === 'Fragment') {
+        return;
       }
+
+      newAttributes.push(t.jSXAttribute(
+        t.jSXIdentifier(nodeNameAttr),
+        t.stringLiteral(elementName),
+      ));
 
       let name;
       if (state.file && state.file.opts) {

--- a/test/fixtures/react-fragment/actual.js
+++ b/test/fixtures/react-fragment/actual.js
@@ -1,0 +1,11 @@
+React.createClass({
+  render: function() {
+    return (
+      <React.Fragment>
+        <Fragment>
+          Element contents
+        </Fragment>
+      </React.Fragment>
+    );
+  },
+});

--- a/test/fixtures/react-fragment/expected.js
+++ b/test/fixtures/react-fragment/expected.js
@@ -1,0 +1,9 @@
+React.createClass({
+  render: function () {
+    return <React.Fragment>
+        <Fragment>
+          Element contents
+        </Fragment>
+      </React.Fragment>;
+  }
+});


### PR DESCRIPTION
Hey @suprraz,

Thanks for this useful tool. Recently we got a lot of warnings from `<React.Fragement/>`. The `qa-node-name` and `qa-node-file` are useless for this special node. Do you mind to review and merge this pull request so that we can get rid of this warning?